### PR TITLE
Fix autocmd filetype error

### DIFF
--- a/autoload/pipenv.vim
+++ b/autoload/pipenv.vim
@@ -25,7 +25,7 @@ function! pipenv#command(...)
 endfunction
 
 function! pipenv#enable_auto()
-    autocmd filetype python call pipenv#activate()
+    autocmd FileType python call pipenv#activate()
     autocmd BufWinEnter *.py call pipenv#notify()
 endfunction
 


### PR DESCRIPTION
For some reason there is a difference between `filetype` and `FileType` on certain systems. In my case, I was getting an error that `pipenv#activate` as not an event. This should continue to work properly on systems where it's already working.